### PR TITLE
Fix counts on the archive details page

### DIFF
--- a/app/models/archive.coffee
+++ b/app/models/archive.coffee
@@ -54,14 +54,14 @@ class Archive extends Spine.Model
   # progress_strict calculates progress using raw complete and total values from the API
   progress_strict: =>
     unless @stats? then return 0
-    Math.floor(@stats.complete / (@stats.total) * 100)
+    Math.floor(@recordsComplete() / (@stats.total) * 100)
 
   recordsComplete: =>
-    formatNumber @stats.complete
+    formatNumber @stats.total - @stats.active
 
   isComplete: =>
     unless @stats? then return 0
-    @stats.complete >= (@stats.total - @stats.paused)
+    @recordsComplete() >= (@stats.total - @stats.paused)
 
   transcription_count: =>
     @metadata.rows_transcribed || @classification_count || 0

--- a/app/models/archive.coffee
+++ b/app/models/archive.coffee
@@ -60,7 +60,7 @@ class Archive extends Spine.Model
       @stats.total - @stats.active
 
   recordsComplete: =>
-    formatNumber @completedRecords
+    formatNumber @completedRecords()
 
   isComplete: =>
     unless @stats? then return 0

--- a/app/models/archive.coffee
+++ b/app/models/archive.coffee
@@ -54,14 +54,17 @@ class Archive extends Spine.Model
   # progress_strict calculates progress using raw complete and total values from the API
   progress_strict: =>
     unless @stats? then return 0
-    Math.floor(@recordsComplete() / (@stats.total) * 100)
+    Math.floor(@completedRecords() / (@stats.total) * 100)
+
+  completedRecords: =>
+      @stats.total - @stats.active
 
   recordsComplete: =>
-    formatNumber @stats.total - @stats.active
+    formatNumber @completedRecords
 
   isComplete: =>
     unless @stats? then return 0
-    @recordsComplete() >= (@stats.total - @stats.paused)
+    @completedRecords() >= (@stats.total - @stats.paused)
 
   transcription_count: =>
     @metadata.rows_transcribed || @classification_count || 0

--- a/app/views/archives/archive-details.eco
+++ b/app/views/archives/archive-details.eco
@@ -36,7 +36,7 @@
           <span class="text">PROGRESS</span>
           <span class="api-stat">Total Images: <%- formatNumber @archive.stats.total %></span>
           <span class="api-stat" >Active Images: <%- formatNumber @archive.stats.active %></span>
-          <span class="api-stat">Complete Images: <%- formatNumber @archive.stats.complete %></span>
+          <span class="api-stat">Complete Images: <%- formatNumber @archive.recordsComplete() %></span>
           <span class="api-stat"><%- formatNumber @archive.transcription_count() %> transcriptions completed</span>
         </div>
       </li>


### PR DESCRIPTION
NOTE: This only fixes the archive details page and not the badge counts.

It looks like we changed the criteria for what an active image is midway thru the project. This made the active counts off. To get the information back I re-purposed the unused recordsComplete function in archive.coffee to calculate the completed records as the total minus the active records.
