### PR TITLE
Denormalize subject group onto classification

### DIFF
--- a/app/controllers/interfaces.coffee
+++ b/app/controllers/interfaces.coffee
@@ -43,6 +43,10 @@ class InterfaceController extends Spine.Controller
   saveClassification: ({transcriptions}) =>
     @classification.annotate({step: annotation.stepTitle, value: annotation.value}) for annotation in transcriptions.toJSON()
 
+    # Save collection directly onto classification. Avoids having to do a join via the DB.
+    if Subject.current?.group
+      @classification.annotate group: Subject.current.group
+
     done = =>
       #throttle to allow async POST to succeed on backend before refresh of other data
       setTimeout =>

--- a/app/controllers/interfaces/birds.coffee
+++ b/app/controllers/interfaces/birds.coffee
@@ -96,11 +96,15 @@ class Birds extends Interfaces
     for record in @records
       @classification.annotate record.collect()
 
+    # Save collection directly onto classification. Avoids having to do a join via the DB.
+    if Subject.current?.group
+      @classification.annotate group: Subject.current.group
+
     done = =>
       setTimeout =>
         Institute.fetch()
         Project.fetch()
-        
+
         unless User.current then return
         badges = User.current.badges
         userFetch = User.fetch()
@@ -108,7 +112,7 @@ class Birds extends Interfaces
         userFetch.done =>
           User.current.badges = badges
           @archive?.checkBadges()
-        
+
       , 500
 
     @classification.send done, ->


### PR DESCRIPTION
@rafelafrance A Christopher Dell request for the WeDigBio event.

Records the subject group, if it exists, onto the current classification, so it will be easily accessible in the hourly dumps that they receiving.
